### PR TITLE
Fix erroneous use of name() over methodName()

### DIFF
--- a/lib/src/main/java/io/github/oblarg/oblog/Logger.java
+++ b/lib/src/main/java/io/github/oblarg/oblog/Logger.java
@@ -526,7 +526,7 @@ public class Logger {
                       .withPosition(params.columnIndex(), params.rowIndex())
                       .withSize(params.width(), params.height())
                       .getEntry(),
-                  () -> getFromMethod(supplierFinal, params.methodName()));
+                  () -> getFromMethod(supplierFinal, params.methodName()).get());
             }
           }),
       entry(Log.PDP.class,

--- a/lib/src/main/java/io/github/oblarg/oblog/Logger.java
+++ b/lib/src/main/java/io/github/oblarg/oblog/Logger.java
@@ -526,7 +526,7 @@ public class Logger {
                       .withPosition(params.columnIndex(), params.rowIndex())
                       .withSize(params.width(), params.height())
                       .getEntry(),
-                  () -> getFromMethod(supplierFinal, params.name()));
+                  () -> getFromMethod(supplierFinal, params.methodName()));
             }
           }),
       entry(Log.PDP.class,


### PR DESCRIPTION
The log handler entry for VoltageView erroneously passed the node name to getFromMethod as opposed to the method name. This causes crashes when the value from which the voltage is being measured reaches this branch and does not contain a method matching that of the name for the value in NT.